### PR TITLE
Fix item description tooltips being cut off in crafting menu

### DIFF
--- a/resource/ui/itemselectionpanel.res
+++ b/resource/ui/itemselectionpanel.res
@@ -8,7 +8,7 @@
 		"ypos"			"0"
 		"zpos"			"500"
 		"wide"			"f0"
-		"tall"			"480"
+		"tall"			"400"
 		"autoResize"	"0"
 		"pinCorner"		"0"
 		"visible"		"1"

--- a/resource/ui/mainmenuoverride.res
+++ b/resource/ui/mainmenuoverride.res
@@ -2228,7 +2228,7 @@
 		"fieldName"		"FooterLine"
 		"xpos"			"0"
 		"ypos"			"420"
-		"zpos"			"-5-"
+		"zpos"			"-49"
 		"wide"			"f0"
 		"tall"			"10"
 		"visible"		"1"


### PR DESCRIPTION
Also fix a typo on mainmenu FooterLine (-50 instead of -5-, but -50 doesn't properly place it in front of the footer, so -49).

The crafting menu item tooltips think they have too much space available and get hidden behind the footer area.

Old:
![image](https://user-images.githubusercontent.com/2764675/56782746-4ebc4b00-679d-11e9-99fd-547ee60548cd.png)

New:
![image](https://user-images.githubusercontent.com/2764675/56782990-61834f80-679e-11e9-8c59-95a4d7736378.png)

For reference:
https://github.com/Eniere/idhud/pull/2