### PR TITLE
Fixes for the August 21st patch.

### DIFF
--- a/resource/ui/mainmenuoverride.res
+++ b/resource/ui/mainmenuoverride.res
@@ -645,24 +645,6 @@
 		}
 	}
 
-	"StreamListPanel"
-	{
-		"ControlName"	"CTFStreamListPanel"
-		"fieldName"		"StreamListPanel"
-		"xpos"			"c5"
-		"ypos"			"65"
-		"zpos"			"1"
-		"wide"			"300"
-		"tall"			"350"
-		"visible"		"0"
-		"PaintBackgroundType"	"2"
-		"paintbackground"	"0"
-		"border"		"MainMenuHighlightBorder"
-
-		"navDown"		"SettingsButton"		// when a sub element can't nav down it will pass through this
-		"navLeft"		"WatchStreamButton"	// when a sub element can't nav left it will pass through this
-	}
-
 	"QuestLogButton"
 	{
 		"ControlName"	"EditablePanel"
@@ -1725,22 +1707,12 @@
 				{
 					"0"
 					{
-						"item"		"Winter 2019 Cosmetic Key"
+						"item"		"Summer 2020 Cosmetic Key"
 						"show_market"	"0"
 					}
 					"1"
 					{
-						"item"		"Winter 2019 Cosmetic Case"
-						"show_market"	"1"
-					}
-					"2"
-					{
-						"item"		"Winter 2019 War Paint Key"
-						"show_market"	"0"
-					}
-					"3"
-					{
-						"item"		"Winter 2019 War Paint Case"
+						"item"		"Summer 2020 Cosmetic Case"
 						"show_market"	"1"
 					}
 				}


### PR DESCRIPTION
This commit does the following to make it in-line with live TF2:

1. Remove the StreamListPanel, as now it has been removed from the official HUD files and the button simply links to the Twitch page
2. Replace Winter 2019 cases on the market panel with Summer 2020 ones.

I simply took the current HUD file and merged these 2 differences.